### PR TITLE
#5 Add commerce cart form callback to redirect to cart page.

### DIFF
--- a/docroot/modules/custom/drupalportugal_custom/drupalportugal_custom.info.yml
+++ b/docroot/modules/custom/drupalportugal_custom/drupalportugal_custom.info.yml
@@ -3,19 +3,3 @@ type: module
 description: Customizations needed by the site
 package: Drupal Portugal
 core: 8.x
-dependencies:
-  - aggregator
-  - ctools
-  - diff
-  - config_translation
-  - content_translation
-  - google_analytics
-  - honeypot
-  - language
-  - locale
-  - markdown
-  - metatag
-  - mollom
-  - pathauto
-  - token
-  - views_slideshow

--- a/docroot/modules/custom/drupalportugal_custom/drupalportugal_custom.module
+++ b/docroot/modules/custom/drupalportugal_custom/drupalportugal_custom.module
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Provides sites customizations.
+ */
+
+use Drupal\commerce_cart\Form\AddToCartFormInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function drupalportugal_custom_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  /*
+   * Commerce add to cart form has dynamic form ids.
+   * One of the solutions is to check if Form is instance of AddToCartInterface.
+   */
+  if ($form_state->getFormObject() instanceof AddToCartFormInterface) {
+    /*
+     * Set new submit form callback.
+     */
+    $form["actions"]["submit"]["#submit"][] = "drupalportugal_custom_form_redirect_callback";
+  }
+}
+
+/**
+ * Form submit callback.
+ */
+function drupalportugal_custom_form_redirect_callback($form, FormStateInterface $form_state) {
+  /*
+   * Redirect to commerce_cart page.
+   */
+  $form_state->setRedirect("commerce_cart.page");
+}


### PR DESCRIPTION
**Branch Summary**
Remove module dependencies on drupalportugal_custom.info.yml since module was not being used.
Add drupalportugal_custom.module do implement commerce add to cart form alter.

**Test scenario**

- Enable drupalportugal_custom module
- Clear cache.
- Add product to cart and check if user is being redirected do cart page.
